### PR TITLE
Add `isEmpty()` method for preventing calling `toArray()` to null object

### DIFF
--- a/src/mapbox/LngLatBounds.hx
+++ b/src/mapbox/LngLatBounds.hx
@@ -3,6 +3,7 @@ package mapbox;
 @:jsRequire('mapbox-gl', 'LngLatBounds')
 extern class LngLatBounds {
 	function new(?sw:LngLatLike, ?ne:LngLatLike):Void;
+	function isEmpty():Bool;
 	function extend(?obj:LngLatLike):LngLatBounds;
 	function toArray():Array<Array<Float>>;
 }


### PR DESCRIPTION
Refs:

https://github.com/mapbox/mapbox-gl-js/pull/5917

https://docs.mapbox.com/mapbox-gl-js/api/geography/#lnglatbounds#isempty